### PR TITLE
Support running in descope integration tests docker compose env

### DIFF
--- a/internal/services/remote/remote.go
+++ b/internal/services/remote/remote.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"os"
+	"strings"
 
 	"github.com/descope/authzcache/internal/config"
 	ae "github.com/descope/authzservice/pkg/authzservice/errors"
@@ -12,6 +13,7 @@ import (
 )
 
 var baseURL = os.Getenv(descope.EnvironmentVariableBaseURL)
+var managementKey = strings.Trim(os.Getenv(descope.EnvironmentVariableManagementKey), "\"")
 
 func NewDescopeClientWithProjectID(projectID string) (sdk.Management, error) {
 	if projectID == "" {
@@ -22,6 +24,7 @@ func NewDescopeClientWithProjectID(projectID string) (sdk.Management, error) {
 		SessionJWTViaCookie: true,
 		DescopeBaseURL:      baseURL,
 		LogLevel:            getLogLevel(),
+		ManagementKey:       managementKey,
 	})
 	if err != nil {
 		return nil, err // notest


### PR DESCRIPTION
## Related Issues
Required for: https://github.com/descope/etc/issues/10222

## Related PRs
Required for: https://github.com/descope/integrationtests/pull/11372

## Description
1. Removing surrounding double-quotes when reading the management key env var, needed to correctly read the value assigned in the integration tests docker compose file.
2. Made the usage of the management key env variable more clear and explicit.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

