### PR TITLE
Add HTTP_HOST env var to Docker run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run the service with Docker:
 docker run -d \
   --name authzcache \
   -p 8189:8189 \
+  -e HTTP_HOST=0.0.0.0 \
   -e DESCOPE_MANAGEMENT_KEY=your_management_key_here \
   descope/authzcache:latest
 ```


### PR DESCRIPTION
This pull request updates the Docker run instructions in the `README.md` to clarify how to set the HTTP host for the service.

* Documentation update:
  * Added the `-e HTTP_HOST=0.0.0.0` environment variable to the Docker run example in `README.md` to ensure the service binds to all network interfaces.