### PR TITLE
docs: fixing typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run -d \
 
 ## Health Check
 The service exposes health check endpoints for container orchestration:
-- HTTP: `GET http://localhost:8189/health`
+- HTTP: `GET http://localhost:8189/healthz`
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This pull request makes a small update to the health check documentation in the `README.md` file, correcting the HTTP endpoint path for clarity and accuracy.