### PR TITLE
Add context as a param for creating new errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/descope/authzcache
 go 1.24.6
 
 require (
-	github.com/descope/common v0.0.9-0.20260120112229-54a458a597c2
+	github.com/descope/common v0.0.9-0.20260121105016-a1490863cadd
 	github.com/descope/go-sdk v1.7.0
 	github.com/descope/golang-lru v0.5.5-0.20220516120313-0c580df2ac14
 	github.com/descope/protoc-gen-mocker v1.0.1-0.20260119161505-525f3cf04e27

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/descope/authzservice v0.0.0-20260120162657-6cb88f4aabb2 h1:2iGHQwu21bgvZCQREQmiI3VhulDDwLgpBrPRU4F60Ac=
 github.com/descope/authzservice v0.0.0-20260120162657-6cb88f4aabb2/go.mod h1:Pus4wRK8z5SITrocG9ZfSdIL02UU2qAAx0bDKKJkTjQ=
-github.com/descope/common v0.0.9-0.20260120112229-54a458a597c2 h1:YPLXque/GDbsEbjPZ4dk6LATfIm1Y2VQKMe9tgsa6HQ=
-github.com/descope/common v0.0.9-0.20260120112229-54a458a597c2/go.mod h1:ULTYA8n7ccuFaHEAvAT3TB+UUmKXK/8wGg5YhXX7LyI=
+github.com/descope/common v0.0.9-0.20260121105016-a1490863cadd h1:15SIX/YcDJndoiFyhAyb6cWPoXzrF0iMhgYxSsmP+jk=
+github.com/descope/common v0.0.9-0.20260121105016-a1490863cadd/go.mod h1:ULTYA8n7ccuFaHEAvAT3TB+UUmKXK/8wGg5YhXX7LyI=
 github.com/descope/go-sdk v1.7.0 h1:DIRmnA4Q8TDtWdGJ9z0I11+AWMrzyNiiozFH557LrgQ=
 github.com/descope/go-sdk v1.7.0/go.mod h1:lCwCgYOfrgjANMsR2BVe1yfX0Siwd2NjNAig0myWZqY=
 github.com/descope/golang-lru v0.5.5-0.20220516120313-0c580df2ac14 h1:PbCbVsG2ZDPxQkg8WvTZHhOPEwncozXvMjdmFotuljk=

--- a/internal/services/remote/remote.go
+++ b/internal/services/remote/remote.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -17,7 +18,7 @@ var managementKey = strings.Trim(os.Getenv(descope.EnvironmentVariableManagement
 
 func NewDescopeClientWithProjectID(projectID string, loggerInstance logger.LoggerInterface) (sdk.Management, error) {
 	if projectID == "" {
-		return nil, ae.UnknownProject.New("projectID is empty")
+		return nil, ae.UnknownProject.New(context.Background(), "projectID is empty")
 	}
 	descopeClient, err := client.NewWithConfig(&client.Config{
 		ProjectID:           projectID,


### PR DESCRIPTION
So we can handle error params with FF
related to https://github.com/descope/etc/issues/13729
