### PR TITLE
fix(lookups): fix wrongful immediate rejection of lookup candidates that are outside the Check cache

### DIFF
--- a/internal/services/authz.go
+++ b/internal/services/authz.go
@@ -184,17 +184,12 @@ func (a *authzCache) WhoCanAccess(ctx context.Context, resource, relationDefinit
 func (a *authzCache) filterWhoCanAccessCandidates(ctx context.Context, resource, relationDefinition, namespace string, candidates []string) ([]string, error) {
 	relations := make([]*descope.FGARelation, len(candidates))
 	for i, target := range candidates {
-		// TargetType "*" tells authzservice to skip target-type schema validation.
-		// Candidates come from a prior verified WhoCanAccess result; their bindings
-		// are already known good in the cache, and we do not track per-candidate
-		// target types here. The schema DSL grammar excludes "*" as an identifier,
-		// so this cannot collide with a real type name.
 		relations[i] = &descope.FGARelation{
 			Resource:     resource,
 			ResourceType: namespace,
 			Relation:     relationDefinition,
 			Target:       target,
-			TargetType:   "*",
+			TargetType:   "*", // WhoCanAccess is TargetType-agnostic
 		}
 	}
 	checks, err := a.Check(ctx, relations)
@@ -242,13 +237,12 @@ func (a *authzCache) WhatCanTargetAccess(ctx context.Context, target string) ([]
 func (a *authzCache) filterWhatCanTargetAccessCandidates(ctx context.Context, target string, candidates []*descope.AuthzRelation) ([]*descope.AuthzRelation, error) {
 	relations := make([]*descope.FGARelation, len(candidates))
 	for i, r := range candidates {
-		// TargetType "*" — see filterWhoCanAccessCandidates for rationale.
 		relations[i] = &descope.FGARelation{
 			Resource:     r.Resource,
 			ResourceType: r.Namespace,
 			Relation:     r.RelationDefinition,
 			Target:       target,
-			TargetType:   "*",
+			TargetType:   "*", // WhatCanTargetAccess is TargetType-agnostic
 		}
 	}
 	checks, err := a.Check(ctx, relations)

--- a/internal/services/authz.go
+++ b/internal/services/authz.go
@@ -184,11 +184,17 @@ func (a *authzCache) WhoCanAccess(ctx context.Context, resource, relationDefinit
 func (a *authzCache) filterWhoCanAccessCandidates(ctx context.Context, resource, relationDefinition, namespace string, candidates []string) ([]string, error) {
 	relations := make([]*descope.FGARelation, len(candidates))
 	for i, target := range candidates {
+		// TargetType "*" tells authzservice to skip target-type schema validation.
+		// Candidates come from a prior verified WhoCanAccess result; their bindings
+		// are already known good in the cache, and we do not track per-candidate
+		// target types here. The schema DSL grammar excludes "*" as an identifier,
+		// so this cannot collide with a real type name.
 		relations[i] = &descope.FGARelation{
 			Resource:     resource,
 			ResourceType: namespace,
 			Relation:     relationDefinition,
 			Target:       target,
+			TargetType:   "*",
 		}
 	}
 	checks, err := a.Check(ctx, relations)
@@ -236,11 +242,13 @@ func (a *authzCache) WhatCanTargetAccess(ctx context.Context, target string) ([]
 func (a *authzCache) filterWhatCanTargetAccessCandidates(ctx context.Context, target string, candidates []*descope.AuthzRelation) ([]*descope.AuthzRelation, error) {
 	relations := make([]*descope.FGARelation, len(candidates))
 	for i, r := range candidates {
+		// TargetType "*" — see filterWhoCanAccessCandidates for rationale.
 		relations[i] = &descope.FGARelation{
 			Resource:     r.Resource,
 			ResourceType: r.Namespace,
 			Relation:     r.RelationDefinition,
 			Target:       target,
+			TargetType:   "*",
 		}
 	}
 	checks, err := a.Check(ctx, relations)

--- a/internal/services/authz_test.go
+++ b/internal/services/authz_test.go
@@ -336,6 +336,10 @@ func TestWhoCanAccess_CacheHitWithCandidateFiltering(t *testing.T) {
 	checkCallCount := 0
 	mockCache.CheckRelationFunc = func(_ context.Context, r *descope.FGARelation) (allowed bool, direct bool, ok bool) {
 		checkCallCount++
+		// Candidates from WhoCanAccess cache are filtered with a wildcard target
+		// type — authzcache does not track per-candidate target types, and the
+		// backend skips schema validation when it sees "*".
+		require.Equal(t, "*", r.TargetType)
 		if r.Target == "user2" {
 			return false, true, true
 		}
@@ -404,6 +408,8 @@ func TestWhatCanTargetAccess_CacheHitWithCandidateFiltering(t *testing.T) {
 	checkCallCount := 0
 	mockCache.CheckRelationFunc = func(_ context.Context, r *descope.FGARelation) (allowed bool, direct bool, ok bool) {
 		checkCallCount++
+		// See filterWhoCanAccessCandidates: candidates are filtered with wildcard target type.
+		require.Equal(t, "*", r.TargetType)
 		if r.Resource == "doc2" {
 			return false, true, true
 		}

--- a/internal/services/authz_test.go
+++ b/internal/services/authz_test.go
@@ -336,9 +336,6 @@ func TestWhoCanAccess_CacheHitWithCandidateFiltering(t *testing.T) {
 	checkCallCount := 0
 	mockCache.CheckRelationFunc = func(_ context.Context, r *descope.FGARelation) (allowed bool, direct bool, ok bool) {
 		checkCallCount++
-		// Candidates from WhoCanAccess cache are filtered with a wildcard target
-		// type — authzcache does not track per-candidate target types, and the
-		// backend skips schema validation when it sees "*".
 		require.Equal(t, "*", r.TargetType)
 		if r.Target == "user2" {
 			return false, true, true
@@ -408,7 +405,6 @@ func TestWhatCanTargetAccess_CacheHitWithCandidateFiltering(t *testing.T) {
 	checkCallCount := 0
 	mockCache.CheckRelationFunc = func(_ context.Context, r *descope.FGARelation) (allowed bool, direct bool, ok bool) {
 		checkCallCount++
-		// See filterWhoCanAccessCandidates: candidates are filtered with wildcard target type.
 		require.Equal(t, "*", r.TargetType)
 		if r.Resource == "doc2" {
 			return false, true, true


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15811

## Must
- [x] Tests
- [ ] Documentation (if applicable)