### PR TITLE
fix(ci): build docker images with repo-local Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         uses: ./.github/actions/pack
         with:
           action_token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: Dockerfile
         env:
           RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
           RELEASE_APP_PEM: ${{ secrets.RELEASE_APP_PEM }}
@@ -152,7 +153,7 @@ jobs:
           echo "build_dir=${BUILD_DIR}" >> "${GITHUB_OUTPUT}"
           echo "port=${PORT}" >> "${GITHUB_OUTPUT}"
           echo "repo_name=${REPO_NAME}" >> "${GITHUB_OUTPUT}"
-          echo "dockerfile=vendor/github.com/descope/backend/common/build/docker/service/Dockerfile" >> "${GITHUB_OUTPUT}"
+          echo "dockerfile=Dockerfile" >> "${GITHUB_OUTPUT}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/15906

## In a Nutshell
- Point `pack` + `publish-dockerhub` at repo-local `./Dockerfile`
- Fixes broken main/release docker builds since #488

## Description
Both docker-build jobs built with the vendored **monorepo** Dockerfile (`vendor/github.com/descope/backend/common/build/docker/service/Dockerfile`), which is monorepo-shaped — `COPY . /go/src/github.com/descope/monorepo` then `WORKDIR .../monorepo/$repo_name` — so for this standalone repo the build ran from an empty dir and failed with `package cmd/authzcache/main.go is not in std`. This broke every push to main since #488 (5/11) repointed the module from standalone `descope/authzservice` to the `descope/backend` monorepo. Point both jobs at the repo-local `./Dockerfile`, which is self-contained and correct for a standalone repo.

Out of scope (follow-up): `release-please.yml`'s `publish-dockerhub` has the identical broken path and needs the same one-line change.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)