### PR TITLE
ci: also sync dockerhub short description on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -111,3 +111,5 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: descope/${{ steps.setup-build-args.outputs.repo_name }}
           readme-filepath: ./README.md
+          short-description: "High-performance authorization cache service that accelerates Descope FGA checks within your cluster."
+          enable-url-completion: true


### PR DESCRIPTION
## Related Issues
Internal Slack: Yosi flagged that Docker Hub releases were not updating the README/description on the public repo page, creating documentation gaps for customers.

## In a Nutshell
- `peter-evans/dockerhub-description` now also pushes the **short description** (the one-liner at the top of the Docker Hub repo page)
- Enables `enable-url-completion` so relative links in `README.md` render correctly on Docker Hub

## Description
Inspecting the latest successful `ci.yml` publish-dockerhub run showed the README update step does run and the API PATCH succeeds — the **full** description was being updated. What was not being updated is the **short description** (the small text right under the repo name on Docker Hub), because `short-description` is an optional parameter and was never passed.

This PR adds `short-description` to the `release-please.yml` step (the only remaining publisher after #585).

Note: separately, the `release-please.yml` publish-dockerhub job currently fails at the docker build step on real releases (see the 1.0.0 run) because of the monorepo Dockerfile mismatch tracked as issue #3 from Yosi. That fix is required for this description-update step to actually run on a release. Once that lands and the next release goes out, both descriptions will flow.

## Must
- [ ] Tests (n/a — CI workflow change; verified by triggering a release)
- [ ] Documentation (n/a)
