### PR TITLE
ci: use setup token for release docker build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,13 +40,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PEM }}
-
       - name: Setup repository dependencies
         id: setup
         uses: ./.github/actions/setup
@@ -95,7 +88,7 @@ jobs:
           labels: ${{ steps.meta-dockerhub.outputs.labels }}
           annotations: ${{ steps.meta-dockerhub.outputs.annotations }}
           secrets: |
-            "github_token=${{ steps.app-token.outputs.token }}"
+            "github_token=${{ steps.setup.outputs.token }}"
           build-args: |
             build_dir=${{ steps.setup-build-args.outputs.build_dir }}
             port=${{ steps.setup-build-args.outputs.port }}


### PR DESCRIPTION
## Related Issues
Failed release-please run for 1.0.1: https://github.com/descope/authzcache/actions/runs/26712502310

## In a Nutshell
- `release-please.yml`'s publish-dockerhub job was using a GitHub App token scoped only to `descope/authzcache`
- `go mod download` for `github.com/descope/backend` failed with `fatal: repository 'https://github.com/descope/backend/' not found`
- Switched the docker build secret to the broader token already produced by `./.github/actions/setup` (same pattern that ci.yml's `docker-build` job uses successfully)

## Description
After the monorepo migration in #587, the release-please publish job started failing at the docker build's `go mod download` step. The error was a 404 on `https://github.com/descope/backend`, which looked like a missing-repo issue but is actually a token-scope issue.

The job was generating its build-time GitHub token with `actions/create-github-app-token`, which by default scopes the token to **only the current repository** (`descope/authzcache`). That token cannot clone `descope/backend`, so the build failed before producing an image — which is also why Docker Hub never updated.

`./.github/actions/setup` already runs in the same job and generates a token via `tibdex/github-app-token`, which has the standard GitHub App scope (every repo where the app is installed — both `authzcache` and `backend`). The ci.yml `docker-build` validation job has been using this token successfully (see PR #587's CI run), so switching the docker build secret to it is the minimum-risk fix.

The narrow `actions/create-github-app-token` step in the `release-please` job (used for the actual release-please action) is kept — it only needs to operate on `authzcache`.

## Verification
- Same token pattern is already passing in `ci.yml`'s `docker-build` job on every PR.
- Once this merges, the next release-please run will re-attempt the publish using the broader token.

## Must
- [x] Tests (covered by ci.yml's docker-build job)
- [ ] Documentation (n/a)