### PR TITLE
feat(authzcache): log running image git SHA at startup

### DIFF
--- a/cmd/authzcache/main.go
+++ b/cmd/authzcache/main.go
@@ -40,6 +40,9 @@ func serve() {
 	ctx, err := server.StartServerWithGatewayAndOptions(
 		[]server.RegisterGRPCFunc{
 			func(ctx context.Context, s *grpc.Server) error {
+				cctx.Logger(ctx).Info().
+					Str("git_sha", cconfig.GetGitSha()).
+					Msg("Starting authzcache")
 				reporter.Start(ctx)
 				//authz cache service init
 				as, err := services.New(ctx, caches.NewProjectAuthzCache, remote.NewDescopeClientWithProjectID, collector)


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/16774

## In a Nutshell
- Log `git_sha` once at server startup

## Description
authzcache is deployed by customers from hub.docker.com/r/descope/authzcache, and today the running build isn't visible in its logs. This logs the image's git SHA at startup via the existing `cconfig.GetGitSha()` getter (`GIT_SHA` is already baked into every published image), so a deployment's build can be identified from its logs. No test added — single static log line.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)