### PR TITLE
test(authzcache): verify HTTP_GATEWAY_WRITE_TIMEOUT governs the gateway

### DIFF
--- a/cmd/authzcache/gateway_write_timeout_test.go
+++ b/cmd/authzcache/gateway_write_timeout_test.go
@@ -1,63 +1,110 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"net"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/descope/authzcache/internal/controllers"
+	"github.com/descope/authzcache/internal/middlewares"
+	"github.com/descope/authzcache/internal/services"
+	"github.com/descope/authzcache/internal/services/caches"
+	"github.com/descope/authzcache/internal/services/metrics"
+	authczv1 "github.com/descope/authzcache/pkg/authzcache/proto/v1"
 	cconfig "github.com/descope/backend/common/pkg/common/config"
+	"github.com/descope/go-sdk/descope"
+	"github.com/descope/go-sdk/descope/logger"
+	"github.com/descope/go-sdk/descope/sdk"
+	mgmtmocks "github.com/descope/go-sdk/descope/tests/mocks/mgmt"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-// newGatewayLikeServer mirrors the gateway http.Server timeout wiring in
-// common/pkg/common/grpc/server/server.go, which authzcache uses unmodified.
-func newGatewayLikeServer(handler http.Handler) *http.Server {
-	return &http.Server{
+// startRealGateway wires the real authzcache stack — gateway http.Server → gRPC
+// server → controller → service — mocking only the downstream Descope SDK. The
+// gateway WriteTimeout is taken from config exactly as common/grpc/server does.
+func startRealGateway(t *testing.T, sdkDelay time.Duration) string {
+	t.Helper()
+	ctx := context.Background()
+
+	// only mock: the downstream backend call, made to sleep to simulate a slow check
+	mockSDK := &mgmtmocks.MockManagement{
+		MockAuthz: &mgmtmocks.MockAuthz{},
+		MockFGA: &mgmtmocks.MockFGA{
+			CheckWithContextAssert: func(_ []*descope.FGARelation, _ map[string]any) { time.Sleep(sdkDelay) },
+			CheckWithContextResponse: []*descope.FGACheck{{
+				Allowed:  true,
+				Relation: &descope.FGARelation{Resource: "doc:1", ResourceType: "doc", Relation: "viewer", Target: "user:1", TargetType: "user"},
+				Info:     &descope.FGACheckInfo{Direct: true},
+			}},
+		},
+	}
+	remoteCreator := func(_ string, _ logger.LoggerInterface) (sdk.Management, error) { return mockSDK, nil }
+
+	svc, err := services.New(ctx, caches.NewProjectAuthzCache, remoteCreator, metrics.NewCollector())
+	require.NoError(t, err)
+
+	grpcLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	grpcSrv := grpc.NewServer()
+	authczv1.RegisterAuthzCacheServer(grpcSrv, controllers.New(svc))
+	go func() { _ = grpcSrv.Serve(grpcLn) }()
+	t.Cleanup(grpcSrv.Stop)
+
+	conn, err := grpc.NewClient(grpcLn.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	mux := runtime.NewServeMux()
+	require.NoError(t, authczv1.RegisterAuthzCacheHandler(ctx, mux, conn))
+
+	// gateway http.Server, timeouts wired from config as common/grpc/server does
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{
 		ReadTimeout:       time.Duration(cconfig.GetHTTPGatewayReadTimeout()) * time.Second,
 		WriteTimeout:      time.Duration(cconfig.GetHTTPGatewayWriteTimeout()) * time.Second,
 		IdleTimeout:       time.Duration(cconfig.GetHTTPGatewayIdleTimeout()) * time.Second,
 		ReadHeaderTimeout: time.Duration(cconfig.GetHTTPGatewayReadHeaderTimeout()) * time.Second,
-		Handler:           handler,
+		Handler:           middlewares.ProjectIDParser(ctx)(mux),
 	}
-}
-
-func serveSlow(t *testing.T, delay time.Duration) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	srv := newGatewayLikeServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(delay)
-		w.WriteHeader(http.StatusOK)
-	}))
-	go func() { _ = srv.Serve(ln) }()
+	go func() { _ = srv.Serve(httpLn) }()
 	t.Cleanup(func() { _ = srv.Close() })
-	return ln.Addr().String()
+
+	return httpLn.Addr().String()
 }
 
-func requestErr(t *testing.T, addr string) error {
+func postCheck(t *testing.T, addr string) error {
 	t.Helper()
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get("http://" + addr + "/anything")
+	body := `{"tuples":[{"resource":"doc:1","resourceType":"doc","relation":"viewer","target":"user:1","targetType":"user"}]}`
+	req, err := http.NewRequest(http.MethodPost, "http://"+addr+"/v1/mgmt/fga/check", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer P2example:key")
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
 	if err == nil {
 		_ = resp.Body.Close()
 	}
 	return err
 }
 
-// TestHTTPGatewayWriteTimeoutEnvHasEffect verifies that HTTP_GATEWAY_WRITE_TIMEOUT
-// already governs the authzcache gateway today: a low value severs a slow response
-// (socket hang up), a high value lets the same response through.
-func TestHTTPGatewayWriteTimeoutEnvHasEffect(t *testing.T) {
-	const handlerDelay = 2 * time.Second
+// TestHTTPGatewayWriteTimeoutAffectsCheckEndpoint drives the real /v1/mgmt/fga/check
+// controller endpoint with a slow (mocked) downstream: a low HTTP_GATEWAY_WRITE_TIMEOUT
+// severs the connection (socket hang up), a high one lets the slow response through.
+func TestHTTPGatewayWriteTimeoutAffectsCheckEndpoint(t *testing.T) {
+	const sdkDelay = 3 * time.Second
 
 	t.Run("low HTTP_GATEWAY_WRITE_TIMEOUT cuts the connection", func(t *testing.T) {
 		t.Setenv(cconfig.ConfigKeyHTTPWriteTimeout, "1")
-		require.Error(t, requestErr(t, serveSlow(t, handlerDelay)))
+		require.Error(t, postCheck(t, startRealGateway(t, sdkDelay)))
 	})
 
-	t.Run("high HTTP_GATEWAY_WRITE_TIMEOUT lets the response through", func(t *testing.T) {
-		t.Setenv(cconfig.ConfigKeyHTTPWriteTimeout, "30")
-		require.NoError(t, requestErr(t, serveSlow(t, handlerDelay)))
+	t.Run("high HTTP_GATEWAY_WRITE_TIMEOUT lets the slow response through", func(t *testing.T) {
+		t.Setenv(cconfig.ConfigKeyHTTPWriteTimeout, "10")
+		require.NoError(t, postCheck(t, startRealGateway(t, sdkDelay)))
 	})
 }

--- a/cmd/authzcache/gateway_write_timeout_test.go
+++ b/cmd/authzcache/gateway_write_timeout_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	cconfig "github.com/descope/backend/common/pkg/common/config"
+	"github.com/stretchr/testify/require"
+)
+
+// newGatewayLikeServer mirrors the gateway http.Server timeout wiring in
+// common/pkg/common/grpc/server/server.go, which authzcache uses unmodified.
+func newGatewayLikeServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		ReadTimeout:       time.Duration(cconfig.GetHTTPGatewayReadTimeout()) * time.Second,
+		WriteTimeout:      time.Duration(cconfig.GetHTTPGatewayWriteTimeout()) * time.Second,
+		IdleTimeout:       time.Duration(cconfig.GetHTTPGatewayIdleTimeout()) * time.Second,
+		ReadHeaderTimeout: time.Duration(cconfig.GetHTTPGatewayReadHeaderTimeout()) * time.Second,
+		Handler:           handler,
+	}
+}
+
+func serveSlow(t *testing.T, delay time.Duration) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := newGatewayLikeServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(http.StatusOK)
+	}))
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return ln.Addr().String()
+}
+
+func requestErr(t *testing.T, addr string) error {
+	t.Helper()
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get("http://" + addr + "/anything")
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+// TestHTTPGatewayWriteTimeoutEnvHasEffect verifies that HTTP_GATEWAY_WRITE_TIMEOUT
+// already governs the authzcache gateway today: a low value severs a slow response
+// (socket hang up), a high value lets the same response through.
+func TestHTTPGatewayWriteTimeoutEnvHasEffect(t *testing.T) {
+	const handlerDelay = 2 * time.Second
+
+	t.Run("low HTTP_GATEWAY_WRITE_TIMEOUT cuts the connection", func(t *testing.T) {
+		t.Setenv(cconfig.ConfigKeyHTTPWriteTimeout, "1")
+		require.Error(t, requestErr(t, serveSlow(t, handlerDelay)))
+	})
+
+	t.Run("high HTTP_GATEWAY_WRITE_TIMEOUT lets the response through", func(t *testing.T) {
+		t.Setenv(cconfig.ConfigKeyHTTPWriteTimeout, "30")
+		require.NoError(t, requestErr(t, serveSlow(t, handlerDelay)))
+	})
+}


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17213

## In a Nutshell
- **Test-only**, no production code changes
- Drives the **real** `/v1/mgmt/fga/check` controller endpoint over HTTP: grpc-gateway → gRPC → controller → service
- Mocks **only** the downstream Descope SDK (made to sleep, simulating a slow backend)
- Proves `HTTP_GATEWAY_WRITE_TIMEOUT` governs the endpoint: low value severs the connection (socket hang up), high value lets the slow response through

## Description
Verification requested before shipping the dedicated override in #887: confirm the existing `HTTP_GATEWAY_WRITE_TIMEOUT` env variable actually affects real calls through authzcache today. The test stands up the real controller behind a real grpc-gateway HTTP server (WriteTimeout wired from config exactly as `common/pkg/common/grpc/server/server.go` does) and a real gRPC server, mocking only the downstream `sdk.Management` so its `CheckWithContext` sleeps. A real HTTP `POST /v1/mgmt/fga/check` then demonstrates the env var deciding whether the slow response is cut or delivered.

Not necessarily intended to merge — it exists to make the behavior observable. The dedicated `AUTHZCACHE_HTTP_WRITE_TIMEOUT_IN_SECONDS` override lives in #887.

## Must
- [x] Tests