### PR TITLE
feat(metrics): report cache and index sizes

### DIFF
--- a/cmd/authzcache/main.go
+++ b/cmd/authzcache/main.go
@@ -44,13 +44,15 @@ func serve() {
 				cctx.Logger(ctx).Info().
 					Str("git_sha", cconfig.GetGitSha()).
 					Msg("Starting authzcache")
-				reporter.Start(ctx)
 				//authz cache service init
 				as, err := services.New(ctx, caches.NewProjectAuthzCache, remote.NewDescopeClientWithProjectID, collector)
 				if err != nil {
 					cctx.Logger(ctx).Err(err).Msg("Failed creating authz cache")
 					return err
 				}
+				// provider set before Start: the reporting goroutine reads it
+				reporter.SetCacheStatsProvider(func() map[string]caches.Stats { return as.CacheStats(ctx) })
+				reporter.Start(ctx)
 				ctrl := controllers.New(as)
 				authzcv1.RegisterAuthzCacheServer(s, ctrl)
 				return nil

--- a/internal/services/authz.go
+++ b/internal/services/authz.go
@@ -20,6 +20,7 @@ type AuthzCache interface {
 	Check(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error)
 	WhoCanAccess(ctx context.Context, resource, relationDefinition, namespace string, extraContext map[string]any) ([]string, error)
 	WhatCanTargetAccess(ctx context.Context, target string, extraContext map[string]any) ([]*descope.AuthzRelation, error)
+	CacheStats(ctx context.Context) map[string]caches.Stats
 }
 
 type RemoteClientCreator func(projectID string, logger logger.LoggerInterface) (sdk.Management, error)
@@ -110,10 +111,11 @@ func (a *authzCache) Check(ctx context.Context, relations []*descope.FGARelation
 	}
 	// check all relations against cache in one read-lock; cached conditional grants are re-evaluated against extraContext inside CheckRelations
 	cachedChecks, toCheckViaSDK, indexToCachedChecks := projectCache.CheckRelations(ctx, relations, extraContext)
+	hits := classifyHits(cachedChecks, len(toCheckViaSDK))
 	// if all relations were found in cache, return
 	if len(toCheckViaSDK) == 0 {
 		// candidatesCount = 0 (nothing sent to SDK); filteredCount = 0 (Check doesn't filter, every relation gets an answer)
-		a.recordMetric(ctx, metrics.APICheck, true, 0, 0, len(cachedChecks), start)
+		a.recordMetric(ctx, metrics.APICheck, true, 0, 0, len(cachedChecks), hits, start)
 		return cachedChecks, nil
 	}
 	// fetch missing relations from sdk
@@ -138,7 +140,7 @@ func (a *authzCache) Check(ctx context.Context, relations []*descope.FGARelation
 		}
 	}
 	// candidatesCount = relations sent to SDK (not in cache); filteredCount = 0 (Check doesn't filter, every relation gets an answer)
-	a.recordMetric(ctx, metrics.APICheck, false, len(toCheckViaSDK), 0, len(result), start)
+	a.recordMetric(ctx, metrics.APICheck, false, len(toCheckViaSDK), 0, len(result), hits, start)
 	return result, nil
 }
 
@@ -164,7 +166,7 @@ func hasCacheableConditional(checks []*descope.FGACheck) bool {
 	return false
 }
 
-func (a *authzCache) recordMetric(ctx context.Context, api metrics.APIName, cacheHit bool, candidatesCount, filteredCount, resultSize int, start time.Time) {
+func (a *authzCache) recordMetric(ctx context.Context, api metrics.APIName, cacheHit bool, candidatesCount, filteredCount, resultSize int, relations metrics.RelationCounts, start time.Time) {
 	if a.metricsCollector == nil {
 		return
 	}
@@ -174,7 +176,33 @@ func (a *authzCache) recordMetric(ctx context.Context, api metrics.APIName, cach
 		FilteredCount:   filteredCount,
 		ResultSize:      resultSize,
 		DurationMs:      time.Since(start).Milliseconds(),
+		Relations:       relations,
 	})
+}
+
+func (a *authzCache) CacheStats(ctx context.Context) map[string]caches.Stats {
+	stats := map[string]caches.Stats{}
+	a.projects.Range(func(key, value any) bool {
+		stats[key.(string)] = value.(project).cache.Stats(ctx)
+		return true
+	})
+	return stats
+}
+
+// Mirrors the Info CheckRelations synthesizes: Conditional wins, so conditional hits aren't split.
+func classifyHits(cachedChecks []*descope.FGACheck, misses int) metrics.RelationCounts {
+	rc := metrics.RelationCounts{Misses: int64(misses)}
+	for _, c := range cachedChecks {
+		switch {
+		case c.Info.Conditional:
+			rc.HitsConditional++
+		case c.Info.Direct:
+			rc.HitsDirect++
+		default:
+			rc.HitsIndirect++
+		}
+	}
+	return rc
 }
 
 func (a *authzCache) WhoCanAccess(ctx context.Context, resource, relationDefinition, namespace string, extraContext map[string]any) ([]string, error) {
@@ -194,7 +222,7 @@ func (a *authzCache) WhoCanAccess(ctx context.Context, resource, relationDefinit
 			Int("candidates", len(candidates)).
 			Int("verified", len(verified)).
 			Msg("WhoCanAccess cache hit with candidate filtering")
-		a.recordMetric(ctx, metrics.APIWhoCanAccess, true, len(candidates), len(candidates)-len(verified), len(verified), start)
+		a.recordMetric(ctx, metrics.APIWhoCanAccess, true, len(candidates), len(candidates)-len(verified), len(verified), metrics.RelationCounts{}, start)
 		return verified, nil
 	}
 	targets, err := mgmtSDK.Authz().WhoCanAccess(ctx, resource, relationDefinition, namespace)
@@ -202,7 +230,7 @@ func (a *authzCache) WhoCanAccess(ctx context.Context, resource, relationDefinit
 		return nil, err // notest
 	}
 	projectCache.SetWhoCanAccessCached(ctx, resource, relationDefinition, namespace, targets)
-	a.recordMetric(ctx, metrics.APIWhoCanAccess, false, 0, 0, len(targets), start)
+	a.recordMetric(ctx, metrics.APIWhoCanAccess, false, 0, 0, len(targets), metrics.RelationCounts{}, start)
 	return targets, nil
 }
 
@@ -247,7 +275,7 @@ func (a *authzCache) WhatCanTargetAccess(ctx context.Context, target string, ext
 			Int("candidates", len(candidates)).
 			Int("verified", len(verified)).
 			Msg("WhatCanTargetAccess cache hit with candidate filtering")
-		a.recordMetric(ctx, metrics.APIWhatCanTargetAccess, true, len(candidates), len(candidates)-len(verified), len(verified), start)
+		a.recordMetric(ctx, metrics.APIWhatCanTargetAccess, true, len(candidates), len(candidates)-len(verified), len(verified), metrics.RelationCounts{}, start)
 		return verified, nil
 	}
 	relations, err := mgmtSDK.Authz().WhatCanTargetAccess(ctx, target)
@@ -255,7 +283,7 @@ func (a *authzCache) WhatCanTargetAccess(ctx context.Context, target string, ext
 		return nil, err // notest
 	}
 	projectCache.SetWhatCanTargetAccessCached(ctx, target, relations)
-	a.recordMetric(ctx, metrics.APIWhatCanTargetAccess, false, 0, 0, len(relations), start)
+	a.recordMetric(ctx, metrics.APIWhatCanTargetAccess, false, 0, 0, len(relations), metrics.RelationCounts{}, start)
 	return relations, nil
 }
 

--- a/internal/services/authz_mock.go
+++ b/internal/services/authz_mock.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 
+	"github.com/descope/authzcache/internal/services/caches"
 	"github.com/descope/go-sdk/descope"
 )
 
@@ -16,6 +17,14 @@ type AuthzCacheMock struct {
 	DeleteFGARelationsFunc  func(ctx context.Context, relations []*descope.FGARelation) error
 	WhoCanAccessFunc        func(ctx context.Context, resource, relationDefinition, namespace string, extraContext map[string]any) ([]string, error)
 	WhatCanTargetAccessFunc func(ctx context.Context, target string, extraContext map[string]any) ([]*descope.AuthzRelation, error)
+	CacheStatsFunc          func(ctx context.Context) map[string]caches.Stats
+}
+
+func (a *AuthzCacheMock) CacheStats(ctx context.Context) map[string]caches.Stats {
+	if a.CacheStatsFunc != nil {
+		return a.CacheStatsFunc(ctx)
+	}
+	return nil
 }
 
 func (a *AuthzCacheMock) Check(ctx context.Context, relations []*descope.FGARelation, extraContext map[string]any) ([]*descope.FGACheck, error) {

--- a/internal/services/caches/projectauthzcache.go
+++ b/internal/services/caches/projectauthzcache.go
@@ -65,6 +65,18 @@ type cachedGrant struct {
 	cond    *conditionalCert
 }
 
+// Stats reports only what can be counted exactly, so callers can derive per-entry cost from a real
+// heap reading rather than from assumed struct overheads.
+type Stats struct {
+	DirectEntries   int
+	IndirectEntries int
+	LookupEntries   int
+	// IndexEntries counts key appearances across both direct indexes, which each hold every key once.
+	IndexEntries int
+	// DirectKeyBytes is the data-dependent part of the direct cache: the key strings themselves.
+	DirectKeyBytes int64
+}
+
 type projectAuthzCache struct {
 	schemaCache *descope.FGASchema // schema
 
@@ -105,6 +117,7 @@ type ProjectAuthzCache interface {
 	GetWhatCanTargetAccessCached(ctx context.Context, target string) (relations []*descope.AuthzRelation, ok bool)
 	SetWhatCanTargetAccessCached(ctx context.Context, target string, relations []*descope.AuthzRelation)
 	InvalidateLookupCache(ctx context.Context)
+	Stats(ctx context.Context) Stats
 }
 
 var _ ProjectAuthzCache = &projectAuthzCache{} // ensure projectAuthzCache implements ProjectAuthzCache
@@ -694,6 +707,25 @@ func (pc *projectAuthzCache) SetWhatCanTargetAccessCached(ctx context.Context, t
 		CachedAt:  now,
 		ExpiresAt: now.Add(pc.lookupCacheTTL),
 	})
+}
+
+// Stats walks directKeyComponents for the key bytes, which allocates nothing but is O(entries), so it
+// belongs on the reporting interval rather than anywhere near a request.
+func (pc *projectAuthzCache) Stats(ctx context.Context) Stats {
+	pc.mutex.RLock()
+	defer pc.mutex.RUnlock()
+	s := Stats{
+		DirectEntries:   pc.directRelationCache.Len(ctx),
+		IndirectEntries: pc.indirectRelationCache.Len(ctx),
+		IndexEntries:    2 * len(pc.directKeyComponents), // one appearance per index
+	}
+	if pc.lookupCache != nil {
+		s.LookupEntries = pc.lookupCache.Len(ctx)
+	}
+	for k := range pc.directKeyComponents {
+		s.DirectKeyBytes += int64(len(k))
+	}
+	return s
 }
 
 func (pc *projectAuthzCache) InvalidateLookupCache(ctx context.Context) {

--- a/internal/services/caches/projectauthzcache_mock.go
+++ b/internal/services/caches/projectauthzcache_mock.go
@@ -22,6 +22,14 @@ type ProjectAuthzCacheMock struct {
 	GetWhatCanTargetAccessCachedFunc    func(ctx context.Context, target string) ([]*descope.AuthzRelation, bool)
 	SetWhatCanTargetAccessCachedFunc    func(ctx context.Context, target string, relations []*descope.AuthzRelation)
 	InvalidateLookupCacheFunc           func(ctx context.Context)
+	StatsFunc                           func(ctx context.Context) Stats
+}
+
+func (m *ProjectAuthzCacheMock) Stats(ctx context.Context) Stats {
+	if m.StatsFunc != nil {
+		return m.StatsFunc(ctx)
+	}
+	return Stats{}
 }
 
 func (m *ProjectAuthzCacheMock) GetSchema() *descope.FGASchema {

--- a/internal/services/caches/projectauthzcache_test.go
+++ b/internal/services/caches/projectauthzcache_test.go
@@ -160,6 +160,25 @@ func TestUpdateCacheWithDeletedRelations(t *testing.T) {
 	assert.Equal(t, 0, len(cache.directTargetsIndex), "%v", cache.directTargetsIndex)
 }
 
+func TestStats(t *testing.T) {
+	ctx := context.TODO()
+	cache, _ := setup(t)
+	assert.Equal(t, Stats{}, cache.Stats(ctx))
+
+	direct := &descope.FGARelation{Resource: "folder1", Target: "u1", Relation: "owner"}
+	indirect := &descope.FGARelation{Resource: "folder2", Target: "u2", Relation: "can_edit"}
+	cache.UpdateCacheWithChecks(ctx, []*descope.FGACheck{
+		{Allowed: true, Relation: direct, Info: &descope.FGACheckInfo{Direct: true}},
+		{Allowed: true, Relation: indirect, Info: &descope.FGACheckInfo{Direct: false}},
+	})
+
+	s := cache.Stats(ctx)
+	assert.Equal(t, 1, s.DirectEntries)
+	assert.Equal(t, 1, s.IndirectEntries)
+	assert.Equal(t, 2, s.IndexEntries, "one direct key appears once in each of the two indexes")
+	assert.Equal(t, int64(len(key(direct))), s.DirectKeyBytes)
+}
+
 func TestUpdateCacheWithAddedRelations_AddsToLookupCache(t *testing.T) {
 	ctx := context.TODO()
 	cache, _ := setup(t)

--- a/internal/services/metrics/collector.go
+++ b/internal/services/metrics/collector.go
@@ -20,6 +20,15 @@ type CallMetrics struct {
 	FilteredCount   int
 	ResultSize      int
 	DurationMs      int64
+	Relations       RelationCounts
+}
+
+// RelationCounts breaks a Check batch down per relation, where the rest of CallMetrics is per call.
+type RelationCounts struct {
+	HitsDirect      int64
+	HitsIndirect    int64
+	HitsConditional int64
+	Misses          int64
 }
 
 // AggregatedMetrics accumulates data across many calls.
@@ -36,6 +45,7 @@ type AggregatedMetrics struct {
 	MaxDurationHitsMs   int64
 	MinDurationMissesMs int64
 	MaxDurationMissesMs int64
+	Relations           RelationCounts
 }
 
 func newAggregatedMetrics() *AggregatedMetrics {
@@ -75,6 +85,10 @@ func (c *Collector) Record(projectID string, api APIName, m CallMetrics) {
 	agg.SumCandidates += int64(m.CandidatesCount)
 	agg.SumFiltered += int64(m.FilteredCount)
 	agg.SumResultSize += int64(m.ResultSize)
+	agg.Relations.HitsDirect += m.Relations.HitsDirect
+	agg.Relations.HitsIndirect += m.Relations.HitsIndirect
+	agg.Relations.HitsConditional += m.Relations.HitsConditional
+	agg.Relations.Misses += m.Relations.Misses
 
 	if m.CacheHit {
 		agg.HitCount++

--- a/internal/services/metrics/collector_test.go
+++ b/internal/services/metrics/collector_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRecordAccumulatesRelationCounts(t *testing.T) {
+	c := NewCollector()
+	c.Record("proj1", APICheck, CallMetrics{Relations: RelationCounts{HitsDirect: 2, HitsIndirect: 1, HitsConditional: 1, Misses: 3}})
+	c.Record("proj1", APICheck, CallMetrics{Relations: RelationCounts{HitsIndirect: 1}})
+
+	agg := c.SnapshotAndReset()["proj1"][APICheck]
+	require.NotNil(t, agg)
+	require.Equal(t, RelationCounts{HitsDirect: 2, HitsIndirect: 2, HitsConditional: 1, Misses: 3}, agg.Relations)
+}
+
 func TestRecordAndSnapshot(t *testing.T) {
 	c := NewCollector()
 

--- a/internal/services/metrics/reporter.go
+++ b/internal/services/metrics/reporter.go
@@ -104,18 +104,19 @@ func (r *Reporter) run(ctx context.Context) {
 	}
 }
 
-// logCacheSizes reports exact counts plus the real process heap, so bytes-per-entry can be divided out
-// of a measurement rather than estimated from assumed per-entry overheads. Heap covers the whole
-// process, so the derived figure is an upper bound on what an entry actually costs.
+// logCacheSizes reports exact counts plus the real process heap, so cost per answer can be divided out
+// of a measurement rather than estimated from assumed per-entry overheads. The denominator is cached
+// answers only, so whole-process heap — the indexes included — is charged to the answers that caused
+// it. That keeps index growth visible in the ratio instead of deflating it.
 func (r *Reporter) logCacheSizes(ctx context.Context) {
 	if r.cacheStats == nil {
 		return
 	}
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	var totalEntries int64
+	var cachedAnswers int64
 	for projectID, s := range r.cacheStats() {
-		totalEntries += int64(s.DirectEntries + s.IndirectEntries + s.LookupEntries + s.IndexEntries)
+		cachedAnswers += int64(s.DirectEntries + s.IndirectEntries + s.LookupEntries)
 		cctx.Logger(ctx).Info().
 			Str("project_id", projectID).
 			Int("direct_entries", s.DirectEntries).
@@ -128,9 +129,9 @@ func (r *Reporter) logCacheSizes(ctx context.Context) {
 	event := cctx.Logger(ctx).Info().
 		Float64("heap_inuse_mb", float64(m.HeapInuse)/(1<<20)).
 		Float64("heap_alloc_mb", float64(m.HeapAlloc)/(1<<20)).
-		Int64("total_entries", totalEntries)
-	if totalEntries > 0 {
-		event = event.Float64("heap_bytes_per_entry_max", float64(m.HeapInuse)/float64(totalEntries))
+		Int64("cached_answers", cachedAnswers)
+	if cachedAnswers > 0 {
+		event = event.Float64("heap_bytes_per_answer_max", float64(m.HeapInuse)/float64(cachedAnswers))
 	}
 	event.Msg("FGA cache process memory")
 }

--- a/internal/services/metrics/reporter.go
+++ b/internal/services/metrics/reporter.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
+	"github.com/descope/authzcache/internal/services/caches"
 	cconfig "github.com/descope/backend/common/pkg/common/config"
 	cctx "github.com/descope/backend/common/pkg/common/context"
 	"github.com/descope/backend/common/pkg/common/utils"
@@ -62,6 +64,12 @@ type Reporter struct {
 	interval      time.Duration
 	enabled       bool
 	httpClient    *http.Client
+	cacheStats    func() map[string]caches.Stats
+}
+
+// SetCacheStatsProvider must be called before Start, since the reporting goroutine reads the field.
+func (r *Reporter) SetCacheStatsProvider(f func() map[string]caches.Stats) {
+	r.cacheStats = f
 }
 
 func NewReporter(collector *Collector, baseURL, managementKey string, intervalSeconds int, enabled bool) *Reporter {
@@ -96,7 +104,39 @@ func (r *Reporter) run(ctx context.Context) {
 	}
 }
 
+// logCacheSizes reports exact counts plus the real process heap, so bytes-per-entry can be divided out
+// of a measurement rather than estimated from assumed per-entry overheads. Heap covers the whole
+// process, so the derived figure is an upper bound on what an entry actually costs.
+func (r *Reporter) logCacheSizes(ctx context.Context) {
+	if r.cacheStats == nil {
+		return
+	}
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	var totalEntries int64
+	for projectID, s := range r.cacheStats() {
+		totalEntries += int64(s.DirectEntries + s.IndirectEntries + s.LookupEntries + s.IndexEntries)
+		cctx.Logger(ctx).Info().
+			Str("project_id", projectID).
+			Int("direct_entries", s.DirectEntries).
+			Int("indirect_entries", s.IndirectEntries).
+			Int("lookup_entries", s.LookupEntries).
+			Int("index_entries", s.IndexEntries).
+			Int64("direct_key_bytes", s.DirectKeyBytes).
+			Msg("FGA cache sizes")
+	}
+	event := cctx.Logger(ctx).Info().
+		Float64("heap_inuse_mb", float64(m.HeapInuse)/(1<<20)).
+		Float64("heap_alloc_mb", float64(m.HeapAlloc)/(1<<20)).
+		Int64("total_entries", totalEntries)
+	if totalEntries > 0 {
+		event = event.Float64("heap_bytes_per_entry_max", float64(m.HeapInuse)/float64(totalEntries))
+	}
+	event.Msg("FGA cache process memory")
+}
+
 func (r *Reporter) report(ctx context.Context) {
+	r.logCacheSizes(ctx)
 	snapshot := r.collector.SnapshotAndReset()
 	for projectID, byAPI := range snapshot {
 		if len(byAPI) == 0 {
@@ -104,6 +144,7 @@ func (r *Reporter) report(ctx context.Context) {
 		}
 		payloads := make([]APIMetricsPayload, 0, len(byAPI))
 		for api, agg := range byAPI {
+			logRelationCounts(ctx, projectID, api, agg) // above the guard: an upstream error leaves counts with no call
 			if agg.TotalCalls == 0 {
 				continue
 			}
@@ -116,6 +157,21 @@ func (r *Reporter) report(ctx context.Context) {
 			cctx.Logger(ctx).Error().Err(err).Str("project_id", projectID).Msg("Failed to report FGA cache metrics; metrics for this window are lost")
 		}
 	}
+}
+
+// Logged rather than reported: the metrics endpoint's proto does not accept these fields yet.
+func logRelationCounts(ctx context.Context, projectID string, api APIName, agg *AggregatedMetrics) {
+	if agg.Relations == (RelationCounts{}) {
+		return
+	}
+	cctx.Logger(ctx).Info().
+		Str("project_id", projectID).
+		Str("api", string(api)).
+		Int64("relation_hits_direct", agg.Relations.HitsDirect).
+		Int64("relation_hits_indirect", agg.Relations.HitsIndirect).
+		Int64("relation_hits_conditional", agg.Relations.HitsConditional).
+		Int64("relation_misses", agg.Relations.Misses).
+		Msg("FGA cache relation-level counters")
 }
 
 func buildPayload(api APIName, agg *AggregatedMetrics) APIMetricsPayload {

--- a/internal/services/metrics/reporter_test.go
+++ b/internal/services/metrics/reporter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/descope/authzcache/internal/services/caches"
 	"github.com/descope/backend/common/pkg/common/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,13 @@ func TestReporterPostsMetrics(t *testing.T) {
 	collector.Record("proj1", APIWhoCanAccess, CallMetrics{CacheHit: false, CandidatesCount: 0, FilteredCount: 0, ResultSize: 3, DurationMs: 30})
 
 	reporter := NewReporter(collector, srv.URL, "mgmt-key", 1, true)
+	called := 0
+	reporter.SetCacheStatsProvider(func() map[string]caches.Stats {
+		called++
+		return map[string]caches.Stats{"proj1": {DirectEntries: 2, IndexEntries: 4, DirectKeyBytes: 40}}
+	})
 	reporter.report(context.Background())
+	require.Equal(t, 1, called, "sizes are read once per reporting window")
 
 	require.Equal(t, "Bearer proj1:mgmt-key", receivedAuth)
 	require.Len(t, receivedBody.Metrics, 1)


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/18209

## Related PRs
### Related PRs
- https://github.com/descope/authzcache/pull/907

## In a Nutshell
- Report entry counts per cache and per direct index
- Report the direct cache's key bytes and the process heap
- Aggregate Check hit/miss counters, split direct/indirect/conditional
- Logged, not reported — the endpoint's proto won't take the fields

## Description
Nothing reported how much memory the caches hold, and a Check batch counted as a single hit or miss, so one miss out of fifty read as a miss and the indirect cache's real hit rate was invisible. This logs exact entry counts, key bytes, the process heap and four aggregate hit/miss counters per project — exact numbers rather than estimated MB, since Go can't size a structure without a profiler.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
